### PR TITLE
Sets a correct "focus behaviour" when the application starts.

### DIFF
--- a/content/NST.js
+++ b/content/NST.js
@@ -1629,8 +1629,6 @@ function preg_quote(str, delimiter) {
             if (!konsole.error)
               alert('Shared library version conflict, ' +
                     'please upgrade Uploader extension.');
-            // This one makes NST active on start:
-            document.getElementById('NST_tab').parentNode.selectedIndex = 1;
             main.settings.init();
             NST = new NSTClass();
             main.refresh('init');

--- a/content/tree.xul
+++ b/content/tree.xul
@@ -19,7 +19,7 @@
               type="checkbox"/>
   </menupopup>
   <tabs id="right_toolbox_tabs">
-    <tab id="NST_tab" label="Source" linkedpanel="NSTviewbox" selected="false" persist="selected"/>
+    <tab id="NST_tab" label="Source" linkedpanel="NSTviewbox" selected="false" persist="selected" onfocus="extensions.NST.refresh('tab');"/>
   </tabs>
   <tabpanels id="right_toolbox_tabpanels" persist="selectedIndex">
     <tabpanel flex="1" id="NSTviewbox">

--- a/content/tree.xul
+++ b/content/tree.xul
@@ -19,9 +19,9 @@
               type="checkbox"/>
   </menupopup>
   <tabs id="right_toolbox_tabs">
-    <tab id="NST_tab" label="Source"/>
+    <tab id="NST_tab" label="Source" linkedpanel="NSTviewbox" selected="false" persist="selected"/>
   </tabs>
-  <tabpanels id="right_toolbox_tabpanels">
+  <tabpanels id="right_toolbox_tabpanels" persist="selectedIndex">
     <tabpanel flex="1" id="NSTviewbox">
       <vbox flex="1" id="NST-vbox">
         <hbox align="center" id="NST-tabpanel-hbox">


### PR DESCRIPTION
Hi there!
This, properly setups the correct selection behavior on startup. 
When nst tab was selected on close, will opens selected on start.
When nst tab was closed on app close, will open closed. 

Users ( like me ) don't like the changes of focus forced by app/ext.

Regards,
