### PR TITLE
Fix using tabbed indent with Python

### DIFF
--- a/content/NST.js
+++ b/content/NST.js
@@ -11,6 +11,7 @@
  * Sergey Lerg
  * Roberto Bouzout
  * wa03
+ * Joel Goguen
  *
  * Copyright (c) 2010, Adam Łyskawa
  * All rights reserved.
@@ -665,7 +666,8 @@ function preg_quote(str, delimiter) {
       var parts = line.match(/^(\s*)(.*?)\s*?$/), // main parts of the line
           whitespace = parts[1],
           code = parts[2],
-          indent = whitespace.length / this.indent,
+          // When using tabbed indents with Python, whitespace.length is the indent level
+		  indent = whitespace[0] === '	' ? whitespace.length : whitespace.length / this.indent,
           defBlock = -1, // current def block indentation level
           csBlock = - 1, // current cs block indentation level
           csOffset = 0, // current block relative control structure offset

--- a/install.rdf
+++ b/install.rdf
@@ -4,7 +4,7 @@
   <Description about="urn:mozilla:install-manifest">
     <em:id>NST@nisza.org</em:id>
     <em:name>NST</em:name>
-    <em:version>0.61</em:version>
+    <em:version>0.62</em:version>
     <em:description>A source tree with all the available classes, methods and functions</em:description>
     <em:creator>Adam Lyskawa</em:creator>
     <em:homepageURL>http://community.activestate.com/xpi/nst-new-source-tree</em:homepageURL>


### PR DESCRIPTION
NST assumed using spaces for Python indentation. This update allows using tab or space indents.
