### PR TITLE
Update install.rdf

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -14,7 +14,7 @@
       <Description>
         <em:id>{36E66FA0-F259-11D9-850E-000D935D3368}</em:id>
         <em:minVersion>8.*</em:minVersion>
-        <em:maxVersion>9.*</em:maxVersion>
+        <em:maxVersion>10.*</em:maxVersion>
       </Description>
     </em:targetApplication>
     <em:targetApplication>
@@ -22,7 +22,7 @@
       <Description>
         <em:id>{b1042fb5-9e9c-11db-b107-000d935d3368}</em:id>
         <em:minVersion>8.*</em:minVersion>
-        <em:maxVersion>9.*</em:maxVersion>
+        <em:maxVersion>10.*</em:maxVersion>
       </Description>
     </em:targetApplication>
   </Description>


### PR DESCRIPTION
When I built the XPI by myself it was necessary to change the ''maxVersion'' from ''9.*'' to ''10.*'' in order to install NST in Komodo-Edit-10.